### PR TITLE
Update script to start the mock server in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ npm install
 First, you will want to start the mock server:
 
 ```sh
-npm run start:mocks
+npm run start:apollolunar
 ```
 
 Then you can start the app with:


### PR DESCRIPTION
The script listed in the sample app README to start the mock server (`npm run start:mocks`) doesn’t match what’s in `package.json` (`npm run start:apollolunar`)